### PR TITLE
update molecule position

### DIFF
--- a/origins/molecule_sim.py
+++ b/origins/molecule_sim.py
@@ -2,10 +2,8 @@ import random
 from origins.runners import GraphRunner
 from origins.universe import Ion, Universe, Electric, Exclusion
 
-# atoms = [Ion(x=10, y=10, vx=10, vy=10, mass=10, charge=10, name='A'),
-#        Ion(x=20, y=20, vx=10, vy=10, mass=10, charge=10, name='B')
-size_x = 50
-size_y = 50
+size_x = 5
+size_y = 5
 
 atoms = []
 for i in range(100):
@@ -13,6 +11,6 @@ for i in range(100):
     atom.randomize()
     atoms.append(atom)
 
-universe = Universe(atoms, size_x, size_y, forces=[Electric(0.1), Exclusion(0.1)])
-runner = GraphRunner(universe, interval=(20))
+universe = Universe(atoms, size_x, size_y, forces=[Electric(0.1), Exclusion(0.01)])
+runner = GraphRunner(universe, interval=(10))
 runner.start()

--- a/origins/polar_sim.py
+++ b/origins/polar_sim.py
@@ -2,18 +2,14 @@ import random
 from origins.runners import GraphRunner
 from origins.universe import Ion, Universe, Electric, Exclusion
 
-water = [Ion(x=1.9, y=1, vx=0, vy=0, mass=1, charge=1, name='H'),
-         Ion(x=1.1, y=1.1, vx=0, vy=0, mass=1, charge=1, name='H'),
-         Ion(x=1, y=1, vx=0, vy=0, mass=16, charge=-1, name='O')]
 size_x = 5
 size_y = 5
 
-atoms = []
-for i in range(100):
-    atom = Ion(max_x=size_x, max_y=size_y)
-    atom.randomize()
-    atoms.append(atom)
+water = [Ion(x=1.9, y=1, vx=0, vy=0, mass=1, charge=1, name='H'),
+         Ion(x=1.1, y=1.1, vx=0, vy=0, mass=1, charge=1, name='H'),
+         Ion(x=1, y=1, vx=0, vy=0, mass=16, charge=-1, name='O')]
 
-universe = Universe(water, size_x, size_y, forces=[Electric(0.01), Exclusion(0.01)])
-runner = GraphRunner(universe, interval=(20))
+
+universe = Universe(water, size_x, size_y, forces=[Electric(0.1), Exclusion(0.01)])
+runner = GraphRunner(universe, interval=(10))
 runner.start()

--- a/origins/universe.py
+++ b/origins/universe.py
@@ -265,11 +265,13 @@ class Universe:
             force.apply(self.atoms)
 
         # Separate atoms and molcules and update positions
-        for component in nx.connected_components(self.particle_graph):
-            if len(component) == 1:
-                self.update_atom_position(component.pop(), delta_t)
-            elif len(component) > 1:
-                self.update_molecule_position(component, delta_t)
+        #for component in nx.connected_components(self.particle_graph):
+        #    if len(component) == 1:
+        #        self.update_atom_position(component.pop(), delta_t)
+        #    elif len(component) > 1:
+        #        self.update_molecule_position(component, delta_t)
+        for atom in self.atoms:
+            self.update_atom_position(atom, delta_t)
 
         self.t1 = t2
 


### PR DESCRIPTION
The function update_molecule_position wasn't working quite right. It was applying the inter-atom forces to the whole molecule, and causing the molecule to accelerate.  Using the exclusion force means that we don't have to calculate deflections. I think using the combination of electric force and exclusion force might mean that we don't need special logic to compute molecule positions. Instead, we update_atom_position should be all that we need. I think...

I think this PR solves one problem, the sim looks less buggy, I think it still needs a bit of work the get the atoms to stick to each other better.